### PR TITLE
Added JSON Schema (YAML format) for capture models

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -1,0 +1,118 @@
+---
+id: "http://www.digirati.com/ns/capture-model-schema/0.1#"
+$schema: "http://json-schema.org/draft-06/schema#"
+description: Capture model for annotation studio
+vocabulary:
+  madoc: http://www.digirati.com/ns/madoc#
+  dcterms: http://purl.org/dc/terms/
+  oa: http://www.w3.org/ns/oa#
+  crowds: http://www.digirati.com/ns/crowds#
+mapping:
+  title: dcterms:title
+  description: dcterms:description
+  combine: crowds:derivedAnnoCombine
+  externalise: crowds:derivedAnnoExternalize
+  humanReadable: crowds:derivedAnnoHumanReadable
+  serialize: crowds:derivedAnnoSerialize
+  component: crowds:uiComponent
+  selectorType:
+    '@id': crowds:uiSelectorType
+    '@type': '@id'
+  fields: dcterms:hasPart
+  inputType: 
+    '@id': crowds:uiInputType
+    '@type': '@id'
+  purpose: crowds:derivedAnnoBodyPurpose
+  bodyType:
+    '@id': crowds:derivedAnnoBodyType
+    '@type': '@id'
+  motivatedBy: 
+    '@id': crowds:derivedAnnoMotivatedBy
+    '@type': '@id'
+  required: crowds:uiRequired
+  conformsTo: 
+    '@id': dcterms:conformsTo
+    '@type': '@id'
+type: object
+properties:
+  title:
+    type: string
+    description: dcterms:title
+  description:
+    type: string
+    description: dcterms:description
+  combine:
+    type: boolean
+    default: false
+    description: crowds:derivedAnnoCombine
+  externalise:
+    type: boolean
+    default: false
+    description: crowds:derivedAnnoExternalize
+  humanReadable:
+    type: boolean
+    default: false
+    description: crowds:derivedAnnoHumanReadable
+  serialize:
+    type: boolean
+    default: false
+    description: crowds:derivedAnnoSerialize
+  component:
+    type: string
+    enum:
+      tagging: Tagging
+      resource: Resource
+    description: crowds:uiComponent
+  selectorType:
+    type: string
+    enum:
+      WholeCanvasSelector: 'Whole canvas'
+      madoc:pin: 'Pin selector'
+      madoc:boxdraw: 'Box draw selector'
+  fields:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      properties:
+        title:
+          type: string
+          description: dcterms:title
+        inputType:
+          type: string
+          enum:
+            madoc:textbox: 'Textbox'
+            madoc:fallbackOptions: 'Fallback auto-complete'
+            madoc:hiddenvalue: 'Hidden'
+            madoc:resource: 'Resource'
+            madoc:nullableCaptureModel: 'Nullable resource'
+            madoc:mappicker: 'Map picker'
+            madoc:datepicker: 'Date picker'
+            madoc:textarea: 'Text area'
+            madoc:dropdown: 'Drop down'
+            madoc:autocomplete: 'Autocomplete'
+        purpose:
+          type: string
+          description: crowds:derivedAnnoBodyPurpose
+        bodyType:
+          type: string
+          enum:
+            oa:TextualBody: 'Textual Body'
+          description: crowds:derivedAnnoBodyType
+        motivatedBy:
+          type: string
+          description: crowds:derivedAnnoMotivatedBy
+        required:
+          type: boolean
+          default: false
+          description: crowds:uiRequired
+        conformsTo:
+          type: string
+          description: dcterms:conformsTo
+      required:
+        - title
+        - inputType
+        - conformsTo
+required:
+- title
+- fields


### PR DESCRIPTION
This is mostly pure JSON-Schema, defining field types and their structure. This is not yet feature complete. There will probably have to be 2 schemas. 

- Simplified `madoc:form` schema (this)
- Complete `madoc:choice` schema

### Simplified Madoc form schema
Written using subset of JSON-Schema for simplicity. Using this schema its possible to generate forms, Plain old [insert-language-here] objects, which gets much more complex using `anyOf` or `oneOf`. In theory this schema will be completely valid for creating capture models, however some fields may be ignored (uiInputOptions for example are only applicable when the type is madoc:dropdown)

### Complete Madoc choice schema
As mentioned the fields have some edge cases that are likely to result in a larger JSON-Schema document for full validation. This also extends to Choices and the nesting nature of them. In terms of form and code generation, its unlikely that the Choices will change at all so can be implemented and are also not required to start creating capture models that are valid. The PHP Wilko implementation for example will create choices on the fly if we match multiple capture models. 

The choice schema should be used as a full validation tool, and be less concerned about transforming JSON-LD. My initial idea was to simply compact incoming documents using the `.vocabulary` and then validate the JSON-LD against the schema. Thats as complex a language implementation would need to be to implement a validator, in theory.

In terms of transforming, here is a Javascript snippet using a standard JSON-LD library with standard methods.
```javascript
const jsonld = require('jsonld').promises;
const CaptureModelYaml = require('./schema.yaml');

function transformJsonLd(json) {
  // Add our contexts to the JSON from the schema itself (custom properties)
  json['@context'] = {
    ...CaptureModelYaml.vocabulary,
    ...CaptureModelYaml.mapping
  }
  return new Promise(resolve => {
    // Expand the JSON using our custom context (JSON -> JSON-LD)
    return jsonld.expand(json).then(r => {

      // Compact the JSON to a standard form using only the vocabulary
      return jsonld.compact(r, CaptureModelYaml.vocabulary).then(j=> {

        resolve(j);
      });
    });
  });
}
```

Effectively this will turn something like this, which is easy to perform validation and form building mechanic on:
```
{ 
    selectorType: 'madoc:form' 
}
```

into complete JSON-LD
```
{
   '@context': {
        madoc: http://www.digirati.com/ns/madoc# 
    },
    crowds:uiSelectorType: { 
         '@id': 'madoc:form' 
    }
}
```

and it does that by adding a context like this (from the JSON-Schema below):
```
{
   '@context': {
        selectorType: {
            '@id': 'crowds:uiSelectorType'
            '@type': '@id'
        }
    }
}
```

Transforming in the other direction is simpler, we just apply both contexts, and we get our document:
```javascript
const jsonld = require('jsonld').promises;
const CaptureModelYaml = require('./schema.yaml');

function transformJsonLd(json) {
  // Add our contexts to the JSON from the schema itself (custom properties) and compact
  return jsonld.compact(json, {
           ...CaptureModelYaml.vocabulary,
           ...CaptureModelYaml.mapping
      })
  });
}
```